### PR TITLE
It works on Linux, but there is error in the requirements.txt list

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-selenium-wire=5.*
-selenium=4.*
+selenium-wire==5.*
+selenium==4.*


### PR DESCRIPTION
```
$ pip install -r requirements.txt 
Defaulting to user installation because normal site-packages is not writeable
ERROR: Invalid requirement: 'selenium-wire=5.*' (from line 1 of requirements.txt)
Hint: = is not a valid operator. Did you mean == ?
```